### PR TITLE
Add module docstrings in linalg

### DIFF
--- a/pyhsics/linalg/__init__.py
+++ b/pyhsics/linalg/__init__.py
@@ -1,3 +1,11 @@
+"""Linear algebra primitives exported for public use.
+
+This package exposes common algebraic structures such as ``Scalar`` and
+``Vector`` as well as solvers like ``LinearSystem``.  It gathers the most
+useful pieces of the :mod:`pyhsics.linalg` submodules so they can be imported
+directly from ``pyhsics.linalg``.
+"""
+
 from typing import Union
 
 from pyhsics.linalg.core.algebraic_core import ScalarLike, VectorLike, MatrixLike, Algebraic, T2Algebraic

--- a/pyhsics/linalg/core/algebraic_core.py
+++ b/pyhsics/linalg/core/algebraic_core.py
@@ -1,12 +1,11 @@
-# algebraic_core.py
-# --------------------------------------------------------------
-# Versión “clean‑typing” del núcleo algebraico
-# --------------------------------------------------------------
-#  • Evita isinstance(…, Union[…]) → se usan tuplas reales de tipos.
-#  • Se reemplazan TypeVar bound=Union por TypeAlias y Protocols.
-#  • Se eliminan dependencias cíclicas: los módulos hijo importan ESTO,
-#    no al revés.  Las factorías viven en `T2Algebraic`.
-# --------------------------------------------------------------
+
+"""Core protocols and aliases for the algebraic structures.
+
+This module provides the low level building blocks used by the linear algebra
+objects.  It defines ``ScalarLike`` and friends together with mixin protocols
+implementing common operations.  Modules under :mod:`pyhsics.linalg` rely on
+these definitions to remain type-safe and avoid circular imports.
+"""
 
 from __future__ import annotations
 

--- a/pyhsics/linalg/core/complex_fraction.py
+++ b/pyhsics/linalg/core/complex_fraction.py
@@ -1,3 +1,5 @@
+"""Exact fractional representation of complex numbers."""
+
 from fractions import Fraction
 from math import lcm, gcd
 from typing import Union

--- a/pyhsics/linalg/solvers/affine_map.py
+++ b/pyhsics/linalg/solvers/affine_map.py
@@ -1,3 +1,5 @@
+"""Affine transformations defined by a matrix and a translation vector."""
+
 from __future__ import annotations
 
 from pyhsics.printing.printable import Printable

--- a/pyhsics/linalg/solvers/bilineal_form.py
+++ b/pyhsics/linalg/solvers/bilineal_form.py
@@ -1,3 +1,5 @@
+"""Bilinear forms and related helper methods."""
+
 from __future__ import annotations
 from typing import List, Union
 

--- a/pyhsics/linalg/solvers/linear_map.py
+++ b/pyhsics/linalg/solvers/linear_map.py
@@ -1,0 +1,2 @@
+"""Placeholder for linear map utilities."""
+

--- a/pyhsics/linalg/solvers/linear_system.py
+++ b/pyhsics/linalg/solvers/linear_system.py
@@ -1,3 +1,5 @@
+"""Utilities for solving systems of linear equations."""
+
 import sys
 from typing import List, Optional, Set, Union, Dict, Tuple
 import re

--- a/pyhsics/linalg/spaces/affine_space.py
+++ b/pyhsics/linalg/spaces/affine_space.py
@@ -1,3 +1,5 @@
+"""Implementation of affine spaces built on top of ``Vector`` and ``Point``."""
+
 from pyhsics.linalg.spaces.vector_space import VectorSpace
 from pyhsics.linalg.structures import Point, Vector
 from pyhsics.printing.printable import Printable

--- a/pyhsics/linalg/spaces/vector_space.py
+++ b/pyhsics/linalg/spaces/vector_space.py
@@ -1,3 +1,5 @@
+"""Vector spaces constructed from ``Vector`` objects."""
+
 from typing import Optional, List, Tuple, overload, Union
 from collections import OrderedDict
 

--- a/pyhsics/linalg/structures/__init__.py
+++ b/pyhsics/linalg/structures/__init__.py
@@ -1,3 +1,5 @@
+"""Concrete algebraic structures used across the library."""
+
 from pyhsics.linalg.structures.scalar import Scalar
 from pyhsics.linalg.structures.vector import Vector
 from pyhsics.linalg.structures.point import Point

--- a/pyhsics/linalg/structures/algebraic_map.py
+++ b/pyhsics/linalg/structures/algebraic_map.py
@@ -1,2 +1,4 @@
+"""Utilities for creating symbolic algebraic maps."""
+
 from __future__ import annotations
 

--- a/pyhsics/linalg/structures/matrix/matrix.py
+++ b/pyhsics/linalg/structures/matrix/matrix.py
@@ -1,3 +1,5 @@
+"""Full featured dense matrix implementation."""
+
 from __future__ import annotations
 from functools import cached_property
 from typing import Iterable, List, Literal, Optional, Self, SupportsIndex, Tuple, Union, overload

--- a/pyhsics/linalg/structures/matrix/matrix_core.py
+++ b/pyhsics/linalg/structures/matrix/matrix_core.py
@@ -1,3 +1,5 @@
+"""Internal helpers for the :class:`~pyhsics.linalg.structures.Matrix` class."""
+
 from typing import Iterable, Iterator, List, Tuple
 
 from pyhsics.linalg.core.algebraic_core import Algebraic, MatrixLike, ScalarLike

--- a/pyhsics/linalg/structures/matrix/matrix_methods.py
+++ b/pyhsics/linalg/structures/matrix/matrix_methods.py
@@ -1,3 +1,5 @@
+"""Standalone matrix algorithms used by :class:`Matrix`."""
+
 from pyhsics.linalg.structures import Scalar, Matrix
 
 class MatrixMethods:

--- a/pyhsics/linalg/structures/point.py
+++ b/pyhsics/linalg/structures/point.py
@@ -1,3 +1,5 @@
+"""Representation of points in an affine space."""
+
 from __future__ import annotations
 from typing import Optional, overload, TYPE_CHECKING
 

--- a/pyhsics/linalg/structures/scalar.py
+++ b/pyhsics/linalg/structures/scalar.py
@@ -1,14 +1,4 @@
-# scalar.py  -----------------------------------------------------------
-# Implementación “type‑safe” de Scalar sobre la versión limpia
-# de algebraic_core.py entregada antes.
-# ---------------------------------------------------------------------
-#  •  Hereda únicamente de Algebraic[ScalarLike] y de los mixins
-#     específicos Addable / Multiplyable / MulInvertible previstos
-#     en el núcleo.
-#  •  Aplica sobrecargas (@overload) para __pow__ → ayuda al
-#     type‑checker a inferir el tipo devuelto.
-#  •  Evita imports circulares: sólo depende de algebraic_core.
-# ---------------------------------------------------------------------
+"""Type safe scalar implementation used by the linear algebra module."""
 
 from __future__ import annotations
 

--- a/pyhsics/linalg/structures/vector.py
+++ b/pyhsics/linalg/structures/vector.py
@@ -1,10 +1,4 @@
-# vector.py  ---------------------------------------------------------------
-# Implementación “type‑safe” de Vector alineada con la versión de Scalar.
-# -------------------------------------------------------------------------
-#  • Usa Alias & Protocols definidos en algebraic_core.py
-#  • Mantiene los helpers clásicos (dot, norm, cross…)
-#  • Sólo admite *, / con escalares.  El dot‑product se expone como método.
-# -------------------------------------------------------------------------
+"""Vector type with helpers such as dot product and cross product."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document all modules under `pyhsics.linalg` in English

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'IPython')*

------
https://chatgpt.com/codex/tasks/task_e_68414c9b08c883269aace0264d7c1846